### PR TITLE
Use URI path instead of filesystem path for current document

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,8 +6,8 @@ async function getRepoRootOfFile(workspace, document) {
   const foundFiles = await workspace.findFiles('**/.arcconfig');
   const argconfigDirs = foundFiles
     .map((file) => file.path.replace(/\/.arcconfig$/, ''))
-    .filter((dir) => document.uri.path.startsWith(dir))
-  argconfigDirs.sort((a, b) => a.split('/').length - b.split('/').length)
+    .filter((dir) => document.uri.path.startsWith(dir));
+  argconfigDirs.sort((a, b) => a.split('/').length - b.split('/').length);
   return argconfigDirs[0]; //pick the shortest number of segments (top of tree)
 }
 
@@ -46,7 +46,7 @@ function selectionToUrlRange(selection) {
 }
 
 async function assembleUrl(activeEditor, workspace) {
-  const repoRootPath = await getRepoRootOfFile(workspace, activeEditor.document)
+  const repoRootPath = await getRepoRootOfFile(workspace, activeEditor.document);
   const arcconfig = JSON.parse(await readFilePath(workspace, `${repoRootPath}/.arcconfig`));
   const domain = removeTrailingSlash(getDiffusionDomain(arcconfig));
   const callsign = removeLeadingSlash(removeTrailingSlash(getProjectCallsign(arcconfig)));

--- a/extension.js
+++ b/extension.js
@@ -36,7 +36,7 @@ function getProjectCallsign(arcconfig) {
 }
 
 function documentToProjectFile(document, rootPath) {
-  return document.fileName.replace(rootPath, '');
+  return vscode.Uri.file(document.fileName).path.replace(rootPath, '');
 }
 
 function selectionToUrlRange(selection) {


### PR DESCRIPTION
On *nix OSes the string replacing works with filesystem paths too, but on
Windows the slashes are different.
On Windows URI paths use / while filesystem paths use \.
This makes the extension to work on Windows too.